### PR TITLE
Added basic support for splat (...) operator in PHP 5.6

### DIFF
--- a/src/Feature/FeatureDetector.php
+++ b/src/Feature/FeatureDetector.php
@@ -273,7 +273,7 @@ class FeatureDetector implements FeatureDetectorInterface
                     ->checkInternalMethod('ReflectionParameter', 'isCallable');
             },
 
-            'parameter.splat' => function ($detector) {
+            'parameter.variadic' => function ($detector) {
                 return $detector
                     ->checkStatement('function (...$a) {};');
             },

--- a/src/Feature/FeatureDetector.php
+++ b/src/Feature/FeatureDetector.php
@@ -273,6 +273,11 @@ class FeatureDetector implements FeatureDetectorInterface
                     ->checkInternalMethod('ReflectionParameter', 'isCallable');
             },
 
+            'parameter.splat' => function ($detector) {
+                return $detector
+                    ->checkStatement('function (...$a) {};');
+            },
+
             'reflection.function.export.default.array' => function ($detector) {
                 $function =
                     new ReflectionFunction(function ($a0 = array('a')) {});

--- a/src/Mock/Generator/MockGenerator.php
+++ b/src/Mock/Generator/MockGenerator.php
@@ -323,7 +323,7 @@ EOD;
                 $parameter[1] .
                 '$a' .
                 ++$index .
-                $parameter[2];
+                $parameter[3];
         }
 
         $source .= <<<'EOD'
@@ -408,19 +408,24 @@ EOD;
             }
 
             $parameterCount = count($signature);
+            $variadic       = false;
 
             if ($signature) {
                 $argumentPacking = "\n";
                 $index = -1;
 
                 foreach ($signature as $parameter) {
-                    $argumentPacking .= "\n        if (\$argumentCount > " .
-                        ++$index .
-                        ") {\n            \$arguments[] = " .
-                        $parameter[1] .
-                        '$a' .
-                        $index .
-                        ";\n        }";
+                    if ($parameter[2]) {
+                        $parameterCount--;
+                    } else {
+                        $argumentPacking .= "\n        if (\$argumentCount > " .
+                            ++$index .
+                            ") {\n            \$arguments[] = " .
+                            $parameter[1] .
+                            '$a' .
+                            $index .
+                            ";\n        }";
+                    }
                 }
             } else {
                 $argumentPacking = '';
@@ -475,9 +480,10 @@ EOD;
 
                     $source .= $parameter[0] .
                         $parameter[1] .
+                        $parameter[2] .
                         '$a' .
                         ++$index .
-                        $parameter[2];
+                        $parameter[3];
                 }
 
                 $source .= "\n    ) {\n";

--- a/src/Reflection/FunctionSignatureInspector.php
+++ b/src/Reflection/FunctionSignatureInspector.php
@@ -63,8 +63,8 @@ class FunctionSignatureInspector implements FunctionSignatureInspectorInterface
             ->isSupported('reflection.function.export.default.array');
         $this->isExportReferenceSupported = $featureDetector
             ->isSupported('reflection.function.export.reference');
-        $this->isSplatOperatorSupported = $featureDetector
-            ->isSupported('parameter.splat');
+        $this->isVariadicParameterSupported = $featureDetector
+            ->isSupported('parameter.variadic');
         $this->isHhvm = $featureDetector->isSupported('runtime.hhvm');
     }
 
@@ -145,11 +145,11 @@ class FunctionSignatureInspector implements FunctionSignatureInspectorInterface
                 $byReference = $parameter->isPassedByReference() ? '&' : '';
             } // @codeCoverageIgnoreEnd
 
-            if ($this->isSplatOperatorSupported && $parameter->isVariadic()) {
-                $splat = '...';
+            if ($this->isVariadicParameterSupported && $parameter->isVariadic()) {
+                $variadic = '...';
                 $optional = false;
             } else {
-                $splat = '';
+                $variadic = '';
                 $optional = 'optional' === $match[1];
             }
 
@@ -181,7 +181,7 @@ class FunctionSignatureInspector implements FunctionSignatureInspectorInterface
             }
 
             $signature[$match[4]] =
-                array($typehint, $byReference, $splat, $defaultValue);
+                array($typehint, $byReference, $variadic, $defaultValue);
         }
 
         return $signature;

--- a/test/fixture/feature-detector/features.fixie.yml
+++ b/test/fixture/feature-detector/features.fixie.yml
@@ -22,6 +22,7 @@ data:
  Can yield no value:                                               [generator.yield.nothing,                   '5.5.x',   '999',   [],      '3.4.x',     '999',       []         ]
  Can use a constant as a parameter default value:                  [parameter.default.constant,                '5.4.6.x', '999',   [],      '999',       '0.x',       []         ]
  Can type hint a parameter as callable:                            [parameter.type.callable,                   '5.4.x',   '999',   [],      '0.x',       '999',       []         ]
+ Can unpack parameters with splat operator:                        [parameter.splat,                           '5.6.x',   '999',   [],      '3.3.x',     '999',       []         ]
  Reflection function exports include full array default value:     [reflection.function.export.default.array,  '999',     '0.x',   [],      '3.2.x',     '999',       []         ]
  Reflection function exports include by-reference information:     [reflection.function.export.reference,      '0.x',     '999',   [],      '3.4.x',     '999',       []         ]
  HHVM runtime:                                                     [runtime.hhvm,                              '999',     '0.x',   [],      '0.x',       '999',       []         ]

--- a/test/fixture/feature-detector/features.fixie.yml
+++ b/test/fixture/feature-detector/features.fixie.yml
@@ -22,7 +22,7 @@ data:
  Can yield no value:                                               [generator.yield.nothing,                   '5.5.x',   '999',   [],      '3.4.x',     '999',       []         ]
  Can use a constant as a parameter default value:                  [parameter.default.constant,                '5.4.6.x', '999',   [],      '999',       '0.x',       []         ]
  Can type hint a parameter as callable:                            [parameter.type.callable,                   '5.4.x',   '999',   [],      '0.x',       '999',       []         ]
- Can unpack parameters with splat operator:                        [parameter.splat,                           '5.6.x',   '999',   [],      '3.3.x',     '999',       []         ]
+ Can use variadic parameters:                                      [parameter.variadic,                           '5.6.x',   '999',   [],      '3.3.x',     '999',       []         ]
  Reflection function exports include full array default value:     [reflection.function.export.default.array,  '999',     '0.x',   [],      '3.2.x',     '999',       []         ]
  Reflection function exports include by-reference information:     [reflection.function.export.reference,      '0.x',     '999',   [],      '3.4.x',     '999',       []         ]
  HHVM runtime:                                                     [runtime.hhvm,                              '999',     '0.x',   [],      '0.x',       '999',       []         ]

--- a/test/src/Test/TestInterfaceWithSplat.php
+++ b/test/src/Test/TestInterfaceWithSplat.php
@@ -1,0 +1,17 @@
+<?php
+
+/*
+ * This file is part of the Phony package.
+ *
+ * Copyright © 2015 Erin Millard
+ *
+ * For the full copyright and license information, please view the LICENSE file
+ * that was distributed with this source code.
+ */
+
+namespace Eloquent\Phony\Test;
+
+interface TestInterfaceWithSplat
+{
+    public function method(...$arguments);
+}

--- a/test/src/Test/TestInterfaceWithVariadicParameter.php
+++ b/test/src/Test/TestInterfaceWithVariadicParameter.php
@@ -11,7 +11,7 @@
 
 namespace Eloquent\Phony\Test;
 
-interface TestInterfaceWithSplat
+interface TestInterfaceWithVariadicParameter
 {
     public function method(...$arguments);
 }

--- a/test/suite/FunctionalTest.php
+++ b/test/suite/FunctionalTest.php
@@ -111,13 +111,13 @@ class FunctionalTest extends PHPUnit_Framework_TestCase
         $this->assertNotInstanceOf(get_class($mockMock->mock()), $mock->mock());
     }
 
-    public function testSplatOperatorMocking()
+    public function testVariadicParameterMocking()
     {
-        if (!$this->featureDetector->isSupported('parameter.splat')) {
-            $this->markTestSkipped('Requires splat operator.');
+        if (!$this->featureDetector->isSupported('parameter.variadic')) {
+            $this->markTestSkipped('Requires variadic parameters.');
         }
 
-        $mock = x\mock('Eloquent\Phony\Test\TestInterfaceWithSplat');
+        $mock = x\mock('Eloquent\Phony\Test\TestInterfaceWithVariadicParameter');
         $mock->method->does(
             function () {
                 return func_get_args();

--- a/test/suite/FunctionalTest.php
+++ b/test/suite/FunctionalTest.php
@@ -111,6 +111,25 @@ class FunctionalTest extends PHPUnit_Framework_TestCase
         $this->assertNotInstanceOf(get_class($mockMock->mock()), $mock->mock());
     }
 
+    public function testSplatOperatorMocking()
+    {
+        if (!$this->featureDetector->isSupported('parameter.splat')) {
+            $this->markTestSkipped('Requires splat operator.');
+        }
+
+        $mock = x\mock('Eloquent\Phony\Test\TestInterfaceWithSplat');
+        $mock->method->does(
+            function () {
+                return func_get_args();
+            }
+        );
+
+        $this->assertSame(
+            array(1, 2, 3),
+            $mock->mock()->method(1, 2, 3)
+        );
+    }
+
     public function testSpyStatic()
     {
         $spy = Phony::spy();

--- a/test/suite/Reflection/FunctionSignatureInspectorTest.php
+++ b/test/suite/Reflection/FunctionSignatureInspectorTest.php
@@ -67,22 +67,22 @@ class FunctionSignatureInspectorTest extends PHPUnit_Framework_TestCase
         );
         $actual = $this->subject->signature($function);
         $expected = array(
-            'a' => array('',                                         '',  ''),
-            'b' => array('',                                         '&', ''),
-            'c' => array('array ',                                   '',  ''),
-            'd' => array('array ',                                   '&', ''),
-            'e' => array('\Type ',                                   '',  ''),
-            'f' => array('\Type ',                                   '&', ''),
-            'g' => array('\Namespaced\Type ',                        '',  ''),
-            'h' => array('\Namespaced\Type ',                        '&', ''),
-            'i' => array('\Eloquent\Phony\Feature\FeatureDetector ', '',  ''),
-            'j' => array('',                                         '',  " = 'string'"),
-            'k' => array('',                                         '&', ' = 111'),
-            'm' => array('array ',                                   '&', ' = null'),
-            'n' => array('\Type ',                                   '',  ' = null'),
-            'o' => array('\Type ',                                   '&', ' = null'),
-            'p' => array('\Namespaced\Type ',                        '',  ' = null'),
-            'q' => array('\Namespaced\Type ',                        '&', ' = null'),
+            'a' => array('',                                         '',  '', ''),
+            'b' => array('',                                         '&', '', ''),
+            'c' => array('array ',                                   '',  '', ''),
+            'd' => array('array ',                                   '&', '', ''),
+            'e' => array('\Type ',                                   '',  '', ''),
+            'f' => array('\Type ',                                   '&', '', ''),
+            'g' => array('\Namespaced\Type ',                        '',  '', ''),
+            'h' => array('\Namespaced\Type ',                        '&', '', ''),
+            'i' => array('\Eloquent\Phony\Feature\FeatureDetector ', '',  '', ''),
+            'j' => array('',                                         '',  '', " = 'string'"),
+            'k' => array('',                                         '&', '', ' = 111'),
+            'm' => array('array ',                                   '&', '', ' = null'),
+            'n' => array('\Type ',                                   '',  '', ' = null'),
+            'o' => array('\Type ',                                   '&', '', ' = null'),
+            'p' => array('\Namespaced\Type ',                        '',  '', ' = null'),
+            'q' => array('\Namespaced\Type ',                        '&', '', ' = null'),
         );
 
         $this->assertEquals($expected, $actual);
@@ -105,7 +105,7 @@ class FunctionSignatureInspectorTest extends PHPUnit_Framework_TestCase
         $actual = $this->subject->signature($function);
 
         $this->assertArrayHasKey('a', $actual);
-        $this->assertSame(array('a', 'b', 'c' => 'd'), eval('return $r' . $actual['a'][2] . ';'));
+        $this->assertSame(array('a', 'b', 'c' => 'd'), eval('return $r' . $actual['a'][3] . ';'));
     }
 
     public function testSignatureWithUnavailableDefaultValue()
@@ -113,7 +113,7 @@ class FunctionSignatureInspectorTest extends PHPUnit_Framework_TestCase
         $function = new ReflectionMethod('ReflectionClass', 'getMethods');
         $actual = $this->subject->signature($function);
         $expected = array(
-            'filter' => array('', '', ' = null'),
+            'filter' => array('', '', '', ' = null'),
         );
 
         $this->assertEquals($expected, $actual);
@@ -131,8 +131,8 @@ class FunctionSignatureInspectorTest extends PHPUnit_Framework_TestCase
         );
         $actual = $this->subject->signature($function);
         $expected = array(
-            'a' => array('callable ', '', ''),
-            'b' => array('callable ', '', ' = null'),
+            'a' => array('callable ', '', '', ''),
+            'b' => array('callable ', '', '', ' = null'),
         );
 
         $this->assertEquals($expected, $actual);
@@ -148,8 +148,8 @@ class FunctionSignatureInspectorTest extends PHPUnit_Framework_TestCase
         $function = new ReflectionMethod($this, 'methodA');
         $actual = $this->subject->signature($function);
         $expected = array(
-            'a' => array('', '', ' = 4'),
-            'b' => array('', '', " = 'a'"),
+            'a' => array('', '', '', ' = 4'),
+            'b' => array('', '', '', " = 'a'"),
         );
 
         $this->assertEquals($expected, $actual);
@@ -161,7 +161,7 @@ class FunctionSignatureInspectorTest extends PHPUnit_Framework_TestCase
         $function = new ReflectionMethod($this, 'methodB');
         $actual = $this->subject->signature($function);
         $expected = array(
-            'a' => array('\Eloquent\Phony\Reflection\FunctionSignatureInspectorTest ', '', ''),
+            'a' => array('\Eloquent\Phony\Reflection\FunctionSignatureInspectorTest ', '', '', ''),
         );
 
         $this->assertEquals($expected, $actual);
@@ -172,12 +172,31 @@ class FunctionSignatureInspectorTest extends PHPUnit_Framework_TestCase
     {
         $callback = function ($a, array $b = null) {};
         $expected = array(
-            'a' => array('',       '', ''),
-            'b' => array('array ', '', ' = null'),
+            'a' => array('',       '', '', ''),
+            'b' => array('array ', '', '', ' = null'),
         );
         $actual = $this->subject->callbackSignature($callback);
 
         $this->assertSame($actual, $expected);
+    }
+
+    public function testSignatureWithSplatOperator()
+    {
+        if (!$this->featureDetector->isSupported('parameter.splat')) {
+            $this->markTestSkipped('Requires splat operator.');
+        }
+
+        $code     = 'return function (...$a) { return $args; };';
+        $callback = eval($code);
+        $function = new ReflectionFunction($callback);
+
+        $actual = $this->subject->signature($function);
+        $expected = array(
+            'a' => array('', '', '...',  ''),
+        );
+
+        $this->assertEquals($expected, $actual);
+        $this->assertSame($expected, $actual);
     }
 
     protected function methodA($a = ReflectionMethod::IS_FINAL, $b = self::CONSTANT_A)

--- a/test/suite/Reflection/FunctionSignatureInspectorTest.php
+++ b/test/suite/Reflection/FunctionSignatureInspectorTest.php
@@ -180,10 +180,10 @@ class FunctionSignatureInspectorTest extends PHPUnit_Framework_TestCase
         $this->assertSame($actual, $expected);
     }
 
-    public function testSignatureWithSplatOperator()
+    public function testSignatureWithVariadicParameter()
     {
-        if (!$this->featureDetector->isSupported('parameter.splat')) {
-            $this->markTestSkipped('Requires splat operator.');
+        if (!$this->featureDetector->isSupported('parameter.variadic')) {
+            $this->markTestSkipped('Requires variadic parameters.');
         }
 
         $code     = 'return function (...$a) { return $args; };';

--- a/test/suite/Stub/StubTest.php
+++ b/test/suite/Stub/StubTest.php
@@ -1097,10 +1097,10 @@ class StubTest extends PHPUnit_Framework_TestCase
         $this->assertSame('d', $d);
     }
 
-    public function testStubWithSplatOperator()
+    public function testStubWithVariadicParameter()
     {
-        if (!$this->featureDetector->isSupported('parameter.splat')) {
-            $this->markTestSkipped('Requires splat operator.');
+        if (!$this->featureDetector->isSupported('parameter.variadic')) {
+            $this->markTestSkipped('Requires variadic parameters.');
         }
 
         $code     = 'return function (...$args) { return $args; };';

--- a/test/suite/Stub/StubTest.php
+++ b/test/suite/Stub/StubTest.php
@@ -1096,4 +1096,22 @@ class StubTest extends PHPUnit_Framework_TestCase
         $this->assertSame('c', $c);
         $this->assertSame('d', $d);
     }
+
+    public function testStubWithSplatOperator()
+    {
+        if (!$this->featureDetector->isSupported('parameter.splat')) {
+            $this->markTestSkipped('Requires splat operator.');
+        }
+
+        $code     = 'return function (...$args) { return $args; };';
+        $callback = eval($code);
+
+        $this->subject = new Stub($callback);
+        $this->subject->forwards();
+
+        $this->assertSame(
+            array(1, 2, 3),
+            call_user_func($this->subject, 1, 2, 3)
+        );
+    }
 }


### PR DESCRIPTION
I haven't yet tested references or type-hints in combination with the splat operator.