### PR TITLE
Exception "xdebug_message" is not private.

### DIFF
--- a/src/Exporter/InlineExporter.php
+++ b/src/Exporter/InlineExporter.php
@@ -249,7 +249,7 @@ class InlineExporter implements ExporterInterface
                             $phpValues["\0*\0line"],
                             $phpValues["\0Exception\0trace"],
                             $phpValues["\0Exception\0string"],
-                            $phpValues["\0Exception\0xdebug_message"]
+                            $phpValues["xdebug_message"]
                         );
                         // @codeCoverageIgnoreEnd
                     }

--- a/src/Matcher/EqualToMatcher.php
+++ b/src/Matcher/EqualToMatcher.php
@@ -270,7 +270,7 @@ class EqualToMatcher extends AbstractMatcher
                 $left["\0*\0line"],
                 $left["\0Exception\0trace"],
                 $left["\0Exception\0string"],
-                $left["\0Exception\0xdebug_message"]
+                $left["xdebug_message"]
             );
             // @codeCoverageIgnoreEnd
         }
@@ -292,7 +292,7 @@ class EqualToMatcher extends AbstractMatcher
                 $right["\0*\0line"],
                 $right["\0Exception\0trace"],
                 $right["\0Exception\0string"],
-                $right["\0Exception\0xdebug_message"]
+                $right["xdebug_message"]
             );
             // @codeCoverageIgnoreEnd
         }

--- a/test/benchmarks/Matcher/RecursiveEqualToMatcher.php
+++ b/test/benchmarks/Matcher/RecursiveEqualToMatcher.php
@@ -146,7 +146,7 @@ class RecursiveEqualToMatcher extends AbstractMatcher
                     $left["\x00*\x00line"],
                     $left["\x00Exception\x00trace"],
                     $left["\x00Exception\x00string"],
-                    $left["\x00Exception\x00xdebug_message"]
+                    $left["xdebug_message"]
                 );
                 // @codeCoverageIgnoreEnd
             } else {
@@ -163,7 +163,7 @@ class RecursiveEqualToMatcher extends AbstractMatcher
                     $right["\x00*\x00line"],
                     $right["\x00Exception\x00trace"],
                     $right["\x00Exception\x00string"],
-                    $right["\x00Exception\x00xdebug_message"]
+                    $right["xdebug_message"]
                 );
                 // @codeCoverageIgnoreEnd
             } else {


### PR DESCRIPTION
We were unsetting a mangled name, but it's not private, it's just shoved onto the object by xdebug.