### PR TITLE
Add support for methods names that match tokens in PHP 7.

### DIFF
--- a/src/Feature/FeatureDetector.php
+++ b/src/Feature/FeatureDetector.php
@@ -343,6 +343,12 @@ class FeatureDetector implements FeatureDetectorInterface
                 return 'php' === $detector->runtime();
             },
 
+            'parser.relaxed-keywords' => function ($detector) {
+                // syntax causes fatal on PHP < 7.0 and HHVM
+                return $detector->isSupported('runtime.php') &&
+                    !version_compare(PHP_VERSION, '7.x', '<');
+            },
+
             'trait' => function ($detector) {
                 return $detector
                     ->checkInternalMethod('ReflectionClass', 'isTrait');

--- a/test/fixture/feature-detector/features.json
+++ b/test/fixture/feature-detector/features.json
@@ -32,5 +32,6 @@
     "Reflection function exports include by-reference information":     ["reflection.function.export.reference",      "0.x",     "999",   [], "3.4.x", "999", []],
     "HHVM runtime":                                                     ["runtime.hhvm",                              "999",     "0.x",   [], "0.x",   "999", []],
     "PHP runtime":                                                      ["runtime.php",                               "0.x",     "999",   [], "999",   "0.x", []],
+    "Language keywords can be used as method names":                    ["parser.relaxed-keywords",                   "7.x",     "999",   [], "999",   "0.x", []],
     "Can use traits":                                                   ["trait",                                     "5.4.x",   "999",   [], "0.x",   "999", []]
 }

--- a/test/fixture/mock-generator/relaxed-keywords/builder.php
+++ b/test/fixture/mock-generator/relaxed-keywords/builder.php
@@ -1,0 +1,9 @@
+<?php
+
+return new Eloquent\Phony\Mock\Builder\MockBuilder(
+    'Eloquent\Phony\Test\TestInterfaceWithKeywordMethods',
+    array(
+        'throw' => function () {},
+    ),
+    'MockGeneratorRelaxedKeywords'
+);

--- a/test/fixture/mock-generator/relaxed-keywords/expected.php
+++ b/test/fixture/mock-generator/relaxed-keywords/expected.php
@@ -1,0 +1,42 @@
+<?php
+
+class MockGeneratorRelaxedKeywords
+implements \Eloquent\Phony\Mock\MockInterface,
+           \Eloquent\Phony\Test\TestInterfaceWithKeywordMethods
+{
+    public function return()
+    {
+        $argumentCount = \func_num_args();
+        $arguments = array();
+
+        for ($i = 0; $i < $argumentCount; ++$i) {
+            $arguments[] = \func_get_arg($i);
+        }
+
+        return $this->_proxy->spy(__FUNCTION__)->invokeWith(
+            new \Eloquent\Phony\Call\Argument\Arguments($arguments)
+        );
+    }
+
+    public function throw()
+    {
+        $argumentCount = \func_num_args();
+        $arguments = array();
+
+        for ($i = 0; $i < $argumentCount; ++$i) {
+            $arguments[] = \func_get_arg($i);
+        }
+
+        return $this->_proxy->spy(__FUNCTION__)->invokeWith(
+            new \Eloquent\Phony\Call\Argument\Arguments($arguments)
+        );
+    }
+
+    private static $_uncallableMethods = array(
+  'return' => true,
+);
+    private static $_traitMethods = array();
+    private static $_customMethods = array();
+    private static $_staticProxy;
+    private $_proxy;
+}

--- a/test/fixture/mock-generator/relaxed-keywords/supported.php
+++ b/test/fixture/mock-generator/relaxed-keywords/supported.php
@@ -1,0 +1,5 @@
+<?php
+
+$message = 'Requires relaxed keywords.';
+
+return $detector->isSupported('parser.relaxed-keywords');

--- a/test/src/Test/TestInterfaceWithKeywordMethods.php
+++ b/test/src/Test/TestInterfaceWithKeywordMethods.php
@@ -1,0 +1,18 @@
+<?php
+
+/*
+ * This file is part of the Phony package.
+ *
+ * Copyright © 2015 Erin Millard
+ *
+ * For the full copyright and license information, please view the LICENSE file
+ * that was distributed with this source code.
+ */
+
+namespace Eloquent\Phony\Test;
+
+interface TestInterfaceWithKeywordMethods
+{
+    public function return();
+    public function throw();
+}


### PR DESCRIPTION
For example, its now possible to have a method named `throw`.