### PR TITLE
Default return values for basic iterators, generators, and SPL containers.

### DIFF
--- a/src/Stub/EmptyIteratorAggregate.php
+++ b/src/Stub/EmptyIteratorAggregate.php
@@ -1,0 +1,27 @@
+<?php
+
+/*
+ * This file is part of the Phony package.
+ *
+ * Copyright © 2016 Erin Millard
+ *
+ * For the full copyright and license information, please view the LICENSE file
+ * that was distributed with this source code.
+ */
+
+namespace Eloquent\Phony\Stub;
+
+use EmptyIterator;
+use IteratorAggregate;
+
+/**
+ * An empty iterator aggregate, used as a default return value for callables
+ * with return type hints of IteratorAggregate.
+ */
+final class EmptyIteratorAggregate implements IteratorAggregate
+{
+    public function getIterator()
+    {
+        return new EmptyIterator();
+    }
+}

--- a/src/Stub/Stub.php
+++ b/src/Stub/Stub.php
@@ -30,6 +30,8 @@ use Eloquent\Phony\Stub\Answer\Builder\GeneratorAnswerBuilderInterface;
 use Eloquent\Phony\Stub\Answer\CallRequest;
 use Eloquent\Phony\Stub\Exception\UnusedStubCriteriaException;
 use Eloquent\Phony\Stub\Rule\StubRule;
+use EmptyIterator;
+use Generator;
 use Error;
 use Exception;
 use InvalidArgumentException;
@@ -636,6 +638,35 @@ class Stub extends AbstractWrappedInvocable implements StubInterface
 
                 case 'callable':
                     $value = function () {};
+
+                    break;
+
+                case 'Traversable':
+                case 'Iterator':
+                    $value = new EmptyIterator();
+
+                    break;
+
+                case 'IteratorAggregate':
+                    $value = new EmptyIteratorAggregate();
+
+                    break;
+
+                case 'Generator':
+                    $fn = function () { return; yield; };
+                    $value = $fn();
+
+                    break;
+
+                case 'SplDoublyLinkedList':
+                case 'SplFixedArray':
+                case 'SplMaxHeap':
+                case 'SplMinHeap':
+                case 'SplObjectStorage':
+                case 'SplPriorityQueue':
+                case 'SplQueue':
+                case 'SplStack':
+                    $value = new $type();
 
                     break;
 


### PR DESCRIPTION
Fixes #138 

This might need some feature detection around the generator stuff, though it obviously only works in PHP 7 with return type values anyway - waiting to see how the HHVM builds go on Travis CI.

