### PR TITLE
Fix fatal error on HHVM with nullable type

### DIFF
--- a/src/Reflection/FeatureDetector.php
+++ b/src/Reflection/FeatureDetector.php
@@ -440,6 +440,11 @@ class FeatureDetector
             },
 
             'type.nullable' => function ($detector) {
+                // syntax causes fatal on HHVM
+                if ($detector->isSupported('runtime.hhvm')) {
+                    return false; // @codeCoverageIgnore
+                }
+
                 return $detector->checkStatement(
                     sprintf(
                         'function(?int $a){}',


### PR DESCRIPTION
HHVM does not support the nullable type outside of Hack code.

Broken by 6bf897cb2215ff209ba5e2794c55faaa63d6b4b4

Fixes #203
Refs thephpleague/oauth2-client#584