### PR TITLE
ignore posix_istatty warnings

### DIFF
--- a/src/Reflection/FeatureDetector.php
+++ b/src/Reflection/FeatureDetector.php
@@ -413,7 +413,7 @@ class FeatureDetector
                 }
                 // @codeCoverageIgnoreEnd
 
-                return function_exists('posix_isatty') && posix_isatty(STDOUT);
+                return function_exists('posix_isatty') && @posix_isatty(STDOUT);
             },
 
             'trait' => function ($detector) {


### PR DESCRIPTION
I turned on process isolation in PhpUnit and started getting `posix_isatty(): could not use stream of type 'TEMP'` errors in feature detector.
Google found an easy fix in Symfony, which did the same (https://github.com/symfony/symfony/pull/8939).