### PR TITLE
Prevent fatal errors from leaking

### DIFF
--- a/src/Polyfill/Errors.php
+++ b/src/Polyfill/Errors.php
@@ -1,0 +1,30 @@
+<?php
+
+namespace Eloquent\Phony\Polyfill;
+
+class Errors
+{
+    /**
+     * Clear the last runtime error.
+     *
+     * Prevents feature detection errors from leaking out into shutdown handlers
+     * that look at error_get_last().
+     *
+     * @return void
+     */
+    public static function errorClearLast()
+    {
+        // https://github.com/symfony/polyfill/blob/ba249100f5/src/Php70/Php70.php#L52-L61
+        set_error_handler([__CLASS__, 'silentHandler']);
+        @trigger_error('');
+        restore_error_handler();
+    }
+
+    /**
+     * @return false
+     */
+    public static function silentHandler()
+    {
+        return false;
+    }
+}

--- a/src/Reflection/FeatureDetector.php
+++ b/src/Reflection/FeatureDetector.php
@@ -11,6 +11,7 @@
 
 namespace Eloquent\Phony\Reflection;
 
+use Eloquent\Phony\Polyfill\Errors;
 use Eloquent\Phony\Reflection\Exception\UndefinedFeatureException;
 use Exception;
 use ReflectionClass;
@@ -184,6 +185,10 @@ class FeatureDetector
 
             'error.exception.engine' => function ($detector) {
                 return $detector->checkInternalClass('Error');
+            },
+
+            'error.clear.last' => function ($detector) {
+                return function_exists('error_clear_last');
             },
 
             'generator' => function ($detector) {
@@ -511,6 +516,14 @@ class FeatureDetector
             } catch (Exception $e) {
             }
             // @codeCoverageIgnoreEnd
+        }
+
+        if (false === $result && empty($e)) {
+            if ($this->isSupported('error.clear.last')) {
+                error_clear_last();
+            } else {
+                Errors::errorClearLast();
+            }
         }
 
         error_reporting($reporting);


### PR DESCRIPTION
The errors generated during feature detection are sometimes picked up by
frameworks or libraries that use `error_get_last()` in a shutdown
handler to look for fatal errors.

This change forces an `E_NOTICE` error to be triggered when an error may
potentially be leaked, preventing false positives in *most* situations.

Fixes #209