### PR TITLE
Refactoring tests

### DIFF
--- a/test/suite-edge-cases/EdgeCaseTest.php
+++ b/test/suite-edge-cases/EdgeCaseTest.php
@@ -23,7 +23,7 @@ class EdgeCaseTest extends TestCase
         $full = mock('SimpleXMLElement');
         $mock = $full->get();
 
-        $this->assertTrue($mock instanceof SimpleXMLElement);
+        $this->assertInstanceOf(SimpleXMLElement::class, $mock);
     }
 
     public function testSimpleXmlElementPartial()
@@ -35,8 +35,8 @@ class EdgeCaseTest extends TestCase
         $partial = partialMock('SimpleXMLElement', ['<root><sub></sub></root>']);
         $mock = $partial->get();
 
-        $this->assertTrue($mock instanceof SimpleXMLElement);
-        $this->assertTrue($mock->sub instanceof SimpleXMLElement);
+        $this->assertInstanceOf(SimpleXMLElement::class, $mock);
+        $this->assertInstanceOf(SimpleXMLElement::class, $mock->sub);
     }
 
     public function testSimpleXmlIteratorFull()
@@ -48,7 +48,7 @@ class EdgeCaseTest extends TestCase
         $full = mock('SimpleXMLIterator');
         $mock = $full->get();
 
-        $this->assertTrue($mock instanceof SimpleXMLIterator);
+        $this->assertInstanceOf(SimpleXMLIterator::class, $mock);
     }
 
     public function testSimpleXmlIteratorPartial()
@@ -60,8 +60,8 @@ class EdgeCaseTest extends TestCase
         $partial = partialMock('SimpleXMLIterator', ['<root><sub></sub></root>']);
         $mock = $partial->get();
 
-        $this->assertTrue($mock instanceof SimpleXMLIterator);
-        $this->assertTrue($mock->sub instanceof SimpleXMLIterator);
+        $this->assertInstanceOf(SimpleXMLIterator::class, $mock);
+        $this->assertInstanceOf(SimpleXMLElement::class, $mock->sub);
     }
 
     public function typeData()
@@ -110,7 +110,7 @@ class EdgeCaseTest extends TestCase
         $handle = mock($typeName);
         $mock = $handle->get();
 
-        $this->assertTrue($mock instanceof $typeName);
+        $this->assertInstanceOf($typeName, $mock);
     }
 
     public function functionData()

--- a/test/suite/Call/ArgumentsTest.php
+++ b/test/suite/Call/ArgumentsTest.php
@@ -21,7 +21,7 @@ class ArgumentsTest extends TestCase
     {
         $this->assertSame($this->arguments, $this->subject->all());
         $this->assertSame($this->arguments, iterator_to_array($this->subject));
-        $this->assertSame(2, count($this->subject));
+        $this->assertCount(2, $this->subject);
     }
 
     public function testCopy()

--- a/test/suite/Call/CallDataTest.php
+++ b/test/suite/Call/CallDataTest.php
@@ -39,7 +39,7 @@ class CallDataTest extends TestCase
         $this->assertTrue($this->subject->hasCalls());
         $this->assertSame(1, $this->subject->eventCount());
         $this->assertSame(1, $this->subject->callCount());
-        $this->assertSame(1, count($this->subject));
+        $this->assertCount(1, $this->subject);
         $this->assertNull($this->subject->responseEvent());
         $this->assertSame([], $this->subject->iterableEvents());
         $this->assertNull($this->subject->endEvent());

--- a/test/suite/Call/CallVerifierTest.php
+++ b/test/suite/Call/CallVerifierTest.php
@@ -193,7 +193,7 @@ class CallVerifierTest extends TestCase
         $this->assertTrue($this->subject->hasCalls());
         $this->assertSame(2, $this->subject->eventCount());
         $this->assertSame(1, $this->subject->callCount());
-        $this->assertSame(2, count($this->subject));
+        $this->assertCount(2, $this->subject);
         $this->assertSame($this->calledEvent, $this->subject->calledEvent());
         $this->assertSame($this->returnedEvent, $this->subject->responseEvent());
         $this->assertSame([], $this->subject->iterableEvents());

--- a/test/suite/Event/EventSequenceTest.php
+++ b/test/suite/Event/EventSequenceTest.php
@@ -39,7 +39,7 @@ class EventSequenceTest extends TestCase
         $this->assertSame($this->events, $this->subject->allEvents());
         $this->assertSame(2, $this->subject->callCount());
         $this->assertSame(4, $this->subject->eventCount());
-        $this->assertSame(4, count($this->subject));
+        $this->assertCount(4, $this->subject);
     }
 
     public function testConstructorDefaults()
@@ -52,7 +52,7 @@ class EventSequenceTest extends TestCase
         $this->assertSame([], $this->subject->allCalls());
         $this->assertSame(0, $this->subject->callCount());
         $this->assertSame(0, $this->subject->eventCount());
-        $this->assertSame(0, count($this->subject));
+        $this->assertCount(0, $this->subject);
     }
 
     public function testFirstEvent()

--- a/test/suite/FunctionalTest.php
+++ b/test/suite/FunctionalTest.php
@@ -430,7 +430,7 @@ class FunctionalTest extends TestCase
         $this->assertTrue((bool) $stub->iterated()->produced('c', 'd'));
 
         $this->assertSame('b', $result['a']);
-        $this->assertSame(2, count($result));
+        $this->assertCount(2, $result);
     }
 
     public function testIterableSpyingWithArrayLikeObject()
@@ -452,7 +452,7 @@ class FunctionalTest extends TestCase
         $this->assertTrue((bool) $stub->iterated()->produced('c', 'd'));
 
         $this->assertSame('b', $result['a']);
-        $this->assertSame(2, count($result));
+        $this->assertCount(2, $result);
     }
 
     public function testDefaultStubAnswerCanBeOverridden()

--- a/test/suite/Spy/ArraySpyTest.php
+++ b/test/suite/Spy/ArraySpyTest.php
@@ -36,24 +36,24 @@ class ArraySpyTest extends TestCase
     {
         $this->assertSame('b', $this->subject['a']);
         $this->assertSame('d', $this->subject['c']);
-        $this->assertFalse(isset($this->subject['e']));
+        $this->assertArrayNotHasKey('e', $this->subject);
 
         $this->subject['e'] = 'f';
 
-        $this->assertTrue(isset($this->subject['e']));
+        $this->assertArrayHasKey('e', $this->subject);
         $this->assertSame('f', $this->subject['e']);
 
         unset($this->subject['e']);
 
-        $this->assertFalse(isset($this->subject['e']));
+        $this->assertArrayNotHasKey('e', $this->subject);
     }
 
     public function testCountable()
     {
-        $this->assertSame(2, count($this->subject));
+        $this->assertCount(2, $this->subject);
 
         $this->subject['e'] = 'f';
 
-        $this->assertSame(3, count($this->subject));
+        $this->assertCount(3, $this->subject);
     }
 }

--- a/test/suite/Spy/SpyDataTest.php
+++ b/test/suite/Spy/SpyDataTest.php
@@ -120,12 +120,12 @@ class SpyDataTest extends TestCase
     public function testCallCount()
     {
         $this->assertSame(0, $this->subject->callCount());
-        $this->assertSame(0, count($this->subject));
+        $this->assertCount(0, $this->subject);
 
         $this->subject->addCall($this->callA);
 
         $this->assertSame(1, $this->subject->callCount());
-        $this->assertSame(1, count($this->subject));
+        $this->assertCount(1, $this->subject);
     }
 
     public function testAllEvents()

--- a/test/suite/Spy/SpyVerifierTest.php
+++ b/test/suite/Spy/SpyVerifierTest.php
@@ -257,12 +257,12 @@ class SpyVerifierTest extends TestCase
     public function testCallCount()
     {
         $this->assertSame(0, $this->subject->callCount());
-        $this->assertSame(0, count($this->subject));
+        $this->assertCount(0, $this->subject);
 
         $this->subject->addCall($this->callA);
 
         $this->assertSame(1, $this->subject->callCount());
-        $this->assertSame(1, count($this->subject));
+        $this->assertCount(1, $this->subject);
     }
 
     public function testAllEvents()

--- a/test/suite/Spy/TraversableSpyTest.php
+++ b/test/suite/Spy/TraversableSpyTest.php
@@ -38,24 +38,24 @@ class TraversableSpyTest extends TestCase
     {
         $this->assertSame('b', $this->subject['a']);
         $this->assertSame('d', $this->subject['c']);
-        $this->assertFalse(isset($this->subject['e']));
+        $this->assertArrayNotHasKey('e', $this->subject);
 
         $this->subject['e'] = 'f';
 
-        $this->assertTrue(isset($this->subject['e']));
+        $this->assertArrayHasKey('e', $this->subject);
         $this->assertSame('f', $this->subject['e']);
 
         unset($this->subject['e']);
 
-        $this->assertFalse(isset($this->subject['e']));
+        $this->assertArrayNotHasKey('e', $this->subject);
     }
 
     public function testCountable()
     {
-        $this->assertSame(2, count($this->subject));
+        $this->assertCount(2, $this->subject);
 
         $this->subject['e'] = 'f';
 
-        $this->assertSame(3, count($this->subject));
+        $this->assertCount(3, $this->subject);
     }
 }

--- a/test/suite/Stub/EmptyValueFactoryTest.php
+++ b/test/suite/Stub/EmptyValueFactoryTest.php
@@ -333,7 +333,7 @@ class EmptyValueFactoryTest extends TestCase
         $this->assertInstanceOf($type, $actual);
         $this->assertInstanceOf(Mock::class, $actual);
         $this->assertSame([], iterator_to_array($actual));
-        $this->assertSame(0, count($actual));
+        $this->assertCount(0, $actual);
     }
 
     public function testFromTypeWithArrayAccess()
@@ -343,7 +343,7 @@ class EmptyValueFactoryTest extends TestCase
 
         $this->assertInstanceOf($type, $actual);
         $this->assertInstanceOf(Mock::class, $actual);
-        $this->assertFalse(isset($actual[0]));
+        $this->assertArrayNotHasKey(0, $actual);
     }
 
     public function testFromTypeWithCountable()
@@ -353,7 +353,7 @@ class EmptyValueFactoryTest extends TestCase
 
         $this->assertInstanceOf($type, $actual);
         $this->assertInstanceOf(Mock::class, $actual);
-        $this->assertSame(0, count($actual));
+        $this->assertCount(0, $actual);
     }
 
     public function testFromTypeWithClass()

--- a/test/suite/Verification/GeneratorVerifierTest.php
+++ b/test/suite/Verification/GeneratorVerifierTest.php
@@ -225,12 +225,12 @@ class GeneratorVerifierTest extends TestCase
         $this->setUpWith([]);
 
         $this->assertSame(0, $this->subject->callCount());
-        $this->assertSame(0, count($this->subject));
+        $this->assertCount(0, $this->subject);
 
         $this->setUpWith([$this->callA]);
 
         $this->assertSame(1, $this->subject->callCount());
-        $this->assertSame(1, count($this->subject));
+        $this->assertCount(1, $this->subject);
     }
 
     public function testAllEvents()

--- a/test/suite/Verification/IterableVerifierTest.php
+++ b/test/suite/Verification/IterableVerifierTest.php
@@ -198,12 +198,12 @@ class IterableVerifierTest extends TestCase
         $this->setUpWith([]);
 
         $this->assertSame(0, $this->subject->callCount());
-        $this->assertSame(0, count($this->subject));
+        $this->assertCount(0, $this->subject);
 
         $this->setUpWith([$this->callA]);
 
         $this->assertSame(1, $this->subject->callCount());
-        $this->assertSame(1, count($this->subject));
+        $this->assertCount(1, $this->subject);
     }
 
     public function testAllEvents()


### PR DESCRIPTION
I've refactored some tests, using:
- `assertCount` instead of `count` function;
- `assertArrayHasKey` and `assertArrayNotHasKey` instead of `isset` function;
- `assertInstanceOf` instead of `instanceof` operator.