### PR TITLE
PHP 8.1 compatibility (WIP)

### DIFF
--- a/src/Assertion/Exception/AssertionException.php
+++ b/src/Assertion/Exception/AssertionException.php
@@ -35,12 +35,12 @@ final class AssertionException extends Exception
 
         if (empty($call)) {
             $traceProperty->setValue($exception, []);
-            $fileProperty->setValue($exception, null);
-            $lineProperty->setValue($exception, null);
+            $fileProperty->setValue($exception, '');
+            $lineProperty->setValue($exception, 0);
         } else {
             $traceProperty->setValue($exception, [$call]);
-            $fileProperty->setValue($exception, $call['file'] ?? null);
-            $lineProperty->setValue($exception, $call['line'] ?? null);
+            $fileProperty->setValue($exception, $call['file'] ?? '');
+            $lineProperty->setValue($exception, $call['line'] ?? 0);
         }
     }
 

--- a/src/Mock/MockGenerator.php
+++ b/src/Mock/MockGenerator.php
@@ -265,12 +265,14 @@ EOD;
         if ($returnType) {
             $source .= "\n    ) : " . $returnType . " {\n";
             $isVoidReturn = 'void' === $returnType;
+            $isNeverReturn = 'never' === $returnType;
         } else {
             $source .= "\n    ) {\n";
             $isVoidReturn = false;
+            $isNeverReturn = false;
         }
 
-        if ($isVoidReturn) {
+        if ($isVoidReturn || $isNeverReturn) {
             $source .= <<<'EOD'
         self::$_staticHandle->spy($a0)
             ->invokeWith(new \Eloquent\Phony\Call\Arguments($a1));
@@ -415,9 +417,11 @@ EOD;
             if ($returnType) {
                 $returnTypeSource = ' : ' . $returnType;
                 $isVoidReturn = 'void' === $returnType;
+                $isNeverReturn = 'never' === $returnType;
             } else {
                 $returnTypeSource = '';
                 $isVoidReturn = false;
+                $isNeverReturn = false;
             }
 
             $isStatic = $method->isStatic() ? 'static ' : '';
@@ -446,7 +450,7 @@ EOD;
             $body .=
                 "        }\n\n        if (!${handle}) {\n";
 
-            if ($isVoidReturn) {
+            if ($isVoidReturn || $isNeverReturn) {
                 $resultAssign = '';
             } else {
                 $resultAssign = '$result = ';
@@ -465,6 +469,13 @@ EOD;
             if ($isVoidReturn) {
                 $body .=
                     "\n\n            return;\n        }\n\n" .
+                    "        ${handle}->spy" .
+                    "(__FUNCTION__)->invokeWith(\n" .
+                    '            new \Eloquent\Phony\Call\Arguments' .
+                    "(\$arguments)\n        );";
+            } else if ($isNeverReturn) {
+                $body .=
+                    "\n        }\n\n" .
                     "        ${handle}->spy" .
                     "(__FUNCTION__)->invokeWith(\n" .
                     '            new \Eloquent\Phony\Call\Arguments' .

--- a/src/Reflection/FunctionSignatureInspector.php
+++ b/src/Reflection/FunctionSignatureInspector.php
@@ -125,6 +125,13 @@ class FunctionSignatureInspector
     const RETURN_PATTERN = '/Return \[ (\?)?(\S+) ((?:or NULL )?)/';
 
     /**
+     * Same as above but for tentative return types in PHP 8.1.
+     *
+     * @see https://wiki.php.net/rfc/internal_method_return_types
+     */
+    const TENTATIVE_RETURN_PATTERN = '/Tentative return \[ (\?)?(\S+) ((?:or NULL )?)/';
+
+    /**
      * Get the function signature of the supplied function.
      *
      * @param ReflectionFunctionAbstract $function The function.
@@ -134,11 +141,11 @@ class FunctionSignatureInspector
     public function signature(ReflectionFunctionAbstract $function): array
     {
         $functionString = (string) $function;
-        $hasReturnType = preg_match(
-            static::RETURN_PATTERN,
-            $functionString,
-            $returnMatches
-        );
+        $hasReturnType = preg_match(static::RETURN_PATTERN, $functionString, $returnMatches);
+        // check tentative return type as a fallback for PHP 8.1
+        if (! $hasReturnType) {
+            $hasReturnType = preg_match(static::TENTATIVE_RETURN_PATTERN, $functionString, $returnMatches);
+        }
         $hasParameters = preg_match_all(
             static::PARAMETER_PATTERN,
             $functionString,
@@ -181,6 +188,7 @@ class FunctionSignatureInspector
                     case 'static':
                     case 'string':
                     case 'void':
+                    case 'never':
                         $returnType .= $subType;
 
                         break;

--- a/src/Spy/ArraySpy.php
+++ b/src/Spy/ArraySpy.php
@@ -46,6 +46,7 @@ class ArraySpy implements IterableSpy
      *
      * @return mixed The current key.
      */
+    #[\ReturnTypeWillChange]
     public function key()
     {
         return key($this->array);
@@ -56,6 +57,7 @@ class ArraySpy implements IterableSpy
      *
      * @return mixed The current value.
      */
+    #[\ReturnTypeWillChange]
     public function current()
     {
         return current($this->array);
@@ -129,6 +131,7 @@ class ArraySpy implements IterableSpy
      *
      * @return mixed The value.
      */
+    #[\ReturnTypeWillChange]
     public function offsetGet($key)
     {
         return $this->array[$key];

--- a/src/Spy/TraversableSpy.php
+++ b/src/Spy/TraversableSpy.php
@@ -53,6 +53,7 @@ class TraversableSpy implements IterableSpy
      *
      * @return mixed The current key.
      */
+    #[\ReturnTypeWillChange]
     public function key()
     {
         return $this->key;
@@ -63,6 +64,7 @@ class TraversableSpy implements IterableSpy
      *
      * @return mixed The current value.
      */
+    #[\ReturnTypeWillChange]
     public function current()
     {
         return $this->value;
@@ -167,6 +169,7 @@ class TraversableSpy implements IterableSpy
      *
      * @return mixed The value.
      */
+    #[\ReturnTypeWillChange]
     public function offsetGet($key)
     {
         if (!$this->traversable instanceof ArrayAccess) {

--- a/test/src/Test/TestIteratorAggregate.php
+++ b/test/src/Test/TestIteratorAggregate.php
@@ -13,6 +13,7 @@ class TestIteratorAggregate implements IteratorAggregate
         $this->iterator = $iterator;
     }
 
+    #[\ReturnTypeWillChange]
     public function getIterator()
     {
         return $this->iterator;

--- a/test/src/Test/TupleIterator.php
+++ b/test/src/Test/TupleIterator.php
@@ -13,27 +13,29 @@ class TupleIterator implements Iterator
         $this->tuples = $tuples;
     }
 
+    #[\ReturnTypeWillChange]
     public function current()
     {
         return $this->tuples[key($this->tuples)][1];
     }
 
+    #[\ReturnTypeWillChange]
     public function key()
     {
         return $this->tuples[key($this->tuples)][0];
     }
 
-    public function next()
+    public function next(): void
     {
         next($this->tuples);
     }
 
-    public function rewind()
+    public function rewind(): void
     {
         reset($this->tuples);
     }
 
-    public function valid()
+    public function valid(): bool
     {
         return null !== key($this->tuples);
     }


### PR DESCRIPTION
Handles https://github.com/eloquent/phony/issues/255, the `never` return type and some more issues that showed up as errors when running tests.

There are still some failing tests under PHP 8.1 left to be handled.